### PR TITLE
Add Substack link to sidebar

### DIFF
--- a/src/app/pages/links.tsx
+++ b/src/app/pages/links.tsx
@@ -5,6 +5,7 @@ import {
   FaLinkedin,
   FaEnvelope,
 } from "react-icons/fa";
+import { SiSubstack } from "react-icons/si";
 
 export const links = [
   {
@@ -30,5 +31,11 @@ export const links = [
     title: "Find me on Medium",
     href: "https://johnrho.medium.com/",
     icon: <FaMedium />,
+  },
+  {
+    index: 4,
+    title: "Check out my Substack",
+    href: "https://substack.com/@johnrho",
+    icon: <SiSubstack />,
   },
 ];


### PR DESCRIPTION
## Summary
- add Substack icon import and link in the sidebar links list

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683e5f6e87c4832bbfe469d628ae8cb5