### PR TITLE
Remove Fall 2025 coursework

### DIFF
--- a/public/pages/coursework.md
+++ b/public/pages/coursework.md
@@ -1,13 +1,8 @@
 # 🥇 Technical Coursework (Selected)
 
-## Fall 2025
-- Systems Programming (CS 61, Harvard)
-- Theoretical CS (CS 121, Harvard)
-
 ## Spring 2025
 - Advanced Algorithms (CS 2241 (G), Harvard)
 - Computational Learning Theory (CS 2280 (G), Harvard)
-
 
 ## Fall 2024
 - Intro to Reinforcement Learning (Stat 184, Harvard)


### PR DESCRIPTION
## Summary
- delete the Fall 2025 courses from the coursework page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e5f890578832b9ce808b9573caaaf