### PR TITLE
Add shine animation and profile page

### DIFF
--- a/public/pages/profile.md
+++ b/public/pages/profile.md
@@ -1,0 +1,7 @@
+# 👤 My Profile
+
+![Your Photo Here](https://via.placeholder.com/150 "Add your photo")
+
+## About Me
+Write a brief introduction about yourself here.
+

--- a/src/app/layout/Sidebar.tsx
+++ b/src/app/layout/Sidebar.tsx
@@ -38,6 +38,12 @@ const bubbleAnimation = keyframes`
   }
 `;
 
+const shine = keyframes`
+  0% { filter: brightness(1); }
+  50% { filter: brightness(2); }
+  100% { filter: brightness(1); }
+`;
+
 interface Props {
   expanded: boolean;
   setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
@@ -233,7 +239,12 @@ export default function Sidebar({
           display="flex"
           justifyContent="center"
         >
-          <Box mt={0.7}>
+          <Box
+            mt={0.7}
+            sx={{
+              animation: `${shine} 2s infinite`,
+            }}
+          >
             <VscSettingsGear />
           </Box>
         </Box>

--- a/src/app/pages/pages.ts
+++ b/src/app/pages/pages.ts
@@ -4,4 +4,5 @@ export const pages = [
   { index: 2, name: 'projects.md', route: '/projects' },
   { index: 3, name: 'coursework.md', route: '/coursework' },
   { index: 4, name: 'books.md', route: '/books' },
+  { index: 5, name: 'profile.md', route: '/profile' },
 ];


### PR DESCRIPTION
## Summary
- animate settings icon with a shining effect
- add new profile markdown page
- register profile page in page list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683e611f401c832b924d723121f5c186