### PR TITLE
Add Korean Entrepreneurs Society project

### DIFF
--- a/public/pages/projects.md
+++ b/public/pages/projects.md
@@ -12,3 +12,8 @@
 - Used Spleeter Machine Learning API to split music files into instrumentals for live performances
 - JavaScript, HTML, CSS Flask, Keras
 - Collaborators: Michael Zhao, Jonah Brenner
+
+## [Korean Entrepreneurs Society](https://www.koreanentrepreneurs.org/) 🔗
+- Building the Korean Entrepreneurs Society to connect Korean and Korean American students across startup and venture ecosystems.
+- Despite significant intellectual capital, Korea lacks big players in the artificial intelligence field.
+- A club alone will not solve this, but I hope to foster a community of ambitious students who support one another against the headwinds of the diaspora.


### PR DESCRIPTION
## Summary
- update the projects page with information about the Korean Entrepreneurs Society
- note the goal of connecting Korean and Korean American students to build community
- clarify limitations and aims around AI and diaspora

No profile.md file was found in the repository, so no deletion was necessary.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847a2a25ff8832ba2d1a3fbafe8d3a9